### PR TITLE
Make LoadResourceBy fall through

### DIFF
--- a/lib/speakeasy/load_resource_by.ex
+++ b/lib/speakeasy/load_resource_by.ex
@@ -38,4 +38,6 @@ defmodule Speakeasy.LoadResourceBy do
     options = Keyword.merge(opts, loader: load_resource_by)
     LoadResource.call(resolution, options)
   end
+
+  def call(res, _), do: res
 end

--- a/test/speakeasy/load_resource_by_test.exs
+++ b/test/speakeasy/load_resource_by_test.exs
@@ -42,4 +42,12 @@ defmodule Speakeasy.LoadResourceByTest do
 
     assert context == %Speakeasy.Context{resource: "Received NAME: foo", user: "chauncy"}
   end
+
+  test "doesn't do anything if the resolution is already resolved" do
+    resolution = %{mock_resolution() | state: :resolved}
+    loader = fn id -> {:ok, id} end
+
+    assert resolution ==
+             LoadResourceBy.call(resolution, key: :id, loader: loader)
+  end
 end


### PR DESCRIPTION
LoadResourceById already does so, while LoadResourceBy was still failing for
resolved resolutions

Signed-off-by: Riccardo Binetti <rbino@gmx.com>