### PR TITLE
Allow Authn to bypass nil users, given an option

### DIFF
--- a/test/speakeasy/authn_test.exs
+++ b/test/speakeasy/authn_test.exs
@@ -47,6 +47,19 @@ defmodule Speakeasy.AuthnTest do
     assert result == %{context: %{}, errors: [:unauthenticated], state: :resolved}
   end
 
+  test "given a require: false config, allows the user context to not be present" do
+    resolution = %Absinthe.Resolution{
+      context: %{},
+      errors: [],
+      state: :unresolved
+    }
+
+    %Absinthe.Resolution{context: %{speakeasy: speakeasy}} =
+      Authn.call(resolution, require: false)
+
+    assert speakeasy == %Speakeasy.Context{resource: nil, user: nil}
+  end
+
   test "error message accepts a string" do
     resolution = %{context: %{}, errors: [], state: :unresolved}
 


### PR DESCRIPTION
There are cases, particularly API calls that can be done both when authenticated and not, where we actually may want to allow a `nil` current user.

This is currently not possible because `Authn` always requires a user to be set.

This proposal adds a `require: boolean` option to `Authn` so that, if the user is `nil`, it still sets the Speakeasy context just the same. Defaults to `true` (the current behaviour).

Fixes #12.

Example usage:

```elixir
middleware(Speakeasy.Authn, require: false)
```